### PR TITLE
OP-22934: Runtime policy to validate tags in a pipeline.

### DIFF
--- a/Runtime policies/Tags-Validate.rego
+++ b/Runtime policies/Tags-Validate.rego
@@ -1,0 +1,28 @@
+# This policy denies pipeline execution if a specified application does not have any tags containing any of the required substring.
+# To apply this policy globally, remove the condition that checks for a specific application
+
+package opsmx.spinnaker.tagspolicy
+
+# Define a list of required substrings
+required_substrings = ["BAPP","DEV"]
+
+deny[msg] {
+    # comment below line to use this policy globally for all applications
+    input.application == "application_name"
+    no_required_substring_tags
+        msg := sprintf("Pipeline execution denied: No tag contains any of the required substring '%v'.", [required_substrings])
+    }
+
+    # Rule to check if there are no tags containing any of the required substrings
+    no_required_substring_tags {
+        not any_required_substring_tags
+    }
+
+    # Rule to determine if any tag contains any of the required substrings
+    any_required_substring_tags {
+        some tag
+        input.tags[tag].value != null
+        substr := required_substrings[_]
+        contains(input.tags[tag].value, substr)
+    }
+


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-22934


**Policy functioning** Tested in Dev Environment
This policy can be used for a specific application or globally for all applications with adjustments suggested in policy.
This policy can validate 1 or more tag values as required.
The policy checks whether any of the tags contain at least one of these substrings.
If none of the tags contain any of the substrings from the list, the pipeline is denied, and the message includes all required substrings.

![Screenshot from 2024-12-11 11-53-55](https://github.com/user-attachments/assets/470ceef9-0c7d-4d7e-b4cf-1eab66074636)
